### PR TITLE
Let default uWSGI port be 8080

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -9,7 +9,7 @@ db_user=${DB_USER:-postgres}
 db_password=${DB_PASSWORD}
 db_port=${DB_PORT:-5432}
 
-uwsgi_port=${UWSGI_PORT:-8000}
+uwsgi_port=${UWSGI_PORT:-8080}
 
 until PGPORT=$db_port PGPASSWORD=$db_password psql -h "$db_host" -U "$db_user" -c '\q'; do
   >&2 echo "Waiting for database connection..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     environment:
       - DJANGO_SETTINGS_MODULE=zac.conf.docker
       - SECRET_KEY=${SECRET_KEY}
-      - UWSGI_PORT=8080
     ports:
       - 8080:8080
     depends_on:


### PR DESCRIPTION
Would be nice to let the default port be 8080, as this corresponds with the EXPOSE definition in the Dockerfile.