### PR TITLE
Use correct value for betrokkeneType field

### DIFF
--- a/src/zac/demo/zaakbeheer/views.py
+++ b/src/zac/demo/zaakbeheer/views.py
@@ -709,7 +709,7 @@ class BetrokkeneCreateView(ZACViewMixin, FormView):
         data = {
             'zaak': self.zaak['url'],
             'betrokkene': form_data['betrokkene_url'],
-            'betrokkeneType': 'Natuurlijk persoon',
+            'betrokkeneType': 'natuurlijk_persoon',
             'roltype': form_data['roltype_url'],
             'roltoelichting': form_data['rol_toelichting'],
         }


### PR DESCRIPTION
According to  the api specification the betrokkeneType should be `natuurlijk_persoon`, not `Natuurlijk persoon`.